### PR TITLE
simplify callbacks

### DIFF
--- a/config/engine/supervised.yaml
+++ b/config/engine/supervised.yaml
@@ -8,3 +8,4 @@ criterion:
   _target_: torch.nn.CrossEntropyLoss
 
 mixed_precision: False # bool: train with torch.cuda.amp.autocast
+log_to_wandb: True

--- a/config/train.yaml
+++ b/config/train.yaml
@@ -19,15 +19,11 @@ defaults:
   - engine: supervised.yaml # engine configuration
 
 callbacks:
-  add_lr_scheduler:
-    _target_: src.callbacks.started.add_lr_scheduler
+  # callbacks are set up by specifying functions that are initilized in relation to the event enum values
+  # see https://pytorch.org/ignite/generated/ignite.engine.events.Events.html#ignite.engine.events.Events
+  STARTED:
+    add_lr_scheduler: src.callbacks.started.add_lr_scheduler
+    init_wandb: src.callbacks.started.init_wandb
 
-  init_wandb:
-    _target_: src.callbacks.started.init_wandb
-
-  print_learning_rate:
-    _target_: src.callbacks.epoch_completed.print_learning_rate
-
-  evaluate_model:
-    _target_: src.callbacks.epoch_completed.evaluate_model
-    log_to_wandb: True
+  EPOCH_COMPLETED:
+    log_lr: src.callbacks.epoch_completed.log_lr

--- a/src/callbacks/epoch_completed.py
+++ b/src/callbacks/epoch_completed.py
@@ -1,49 +1,6 @@
 import logging
-import os
-
-import ignite
-import ignite.distributed as idist
-import wandb
-from ignite.engine import Events, create_supervised_evaluator
 
 log = logging.getLogger(__name__)
 
-
-def print_learning_rate(engine):
-    def function(engine):
-        log.info(engine.state.optimizer.param_groups[0]["lr"])
-
-    engine.add_event_handler(Events.EPOCH_COMPLETED, function)
-    
-def evaluate_model(engine, log_to_wandb):
-    # Create Evaluator
-    evaluator = create_supervised_evaluator(
-        engine.state.model,
-        metrics={"accuracy": ignite.metrics.Accuracy(), "loss": ignite.metrics.Loss(engine.state.criterion)},
-        device=idist.device(),
-    )
-    engine.state.evaluator = evaluator
-    def function(engine, log_to_wandb=log_to_wandb):
-        state = engine.state.evaluator.run(engine.state.dataloaders.val)
-        if idist.get_rank() == 0:
-            log.info(state.metrics)
-            if log_to_wandb:
-                wandb.log(state.metrics)
-                log.info("Logged to Wandb")
-    engine.add_event_handler(Events.EPOCH_COMPLETED, function)
-
-
-    # save best 3 models based upon evaluation
-    to_save = {
-        'model': engine.state.model,
-        'engine': engine
-    }
-    handler = ignite.handlers.checkpoint.Checkpoint(
-        to_save, 
-        os.getcwd(),
-        n_saved=3,
-        filename_prefix='best',
-        score_name="accuracy",
-    )
-    log.info(f"Saving best models to: {os.getcwd()}")
-    engine.state.evaluator.add_event_handler(Events.COMPLETED, handler)
+def log_lr(engine):
+    log.info(engine.state.optimizer.param_groups[0]["lr"])

--- a/src/callbacks/started.py
+++ b/src/callbacks/started.py
@@ -5,15 +5,11 @@ from torch.optim.lr_scheduler import StepLR
 
 
 def add_lr_scheduler(engine):
-    def function(engine):
-        torch_lr_scheduler = StepLR(engine.state.optimizer, step_size=8, gamma=0.1)
-        scheduler = LRScheduler(torch_lr_scheduler)
-        engine.add_event_handler(Events.EPOCH_COMPLETED, scheduler)
+    torch_lr_scheduler = StepLR(engine.state.optimizer, step_size=8, gamma=0.1)
+    scheduler = LRScheduler(torch_lr_scheduler)
+    engine.add_event_handler(Events.EPOCH_COMPLETED, scheduler)
 
-    engine.add_event_handler(Events.STARTED, function)
 
 def init_wandb(engine):
-    def function(engine):
-        wandb.login()
-        wandb.init()
-    engine.add_event_handler(Events.STARTED, function)
+    wandb.login()
+    wandb.init()

--- a/src/engines/supervised.py
+++ b/src/engines/supervised.py
@@ -1,28 +1,29 @@
-import hydra
-from omegaconf import DictConfig
+import logging
+import os
 
+import hydra
+import ignite
+import ignite.distributed as idist
 import torch.nn as nn
+import wandb
+from ignite.contrib.handlers import ProgressBar
+from ignite.engine import Engine, Events, create_supervised_evaluator
+from omegaconf import DictConfig
 from torch.cuda.amp import autocast
 
-import ignite.distributed as idist
-from ignite.engine import Engine, Events
-from ignite.contrib.handlers import ProgressBar
-
+log = logging.getLogger(__name__)
 
 def create_engine(model: nn.Module, config: DictConfig):
     """
-    Combines the model and config into an engine
+    Combines the model and config into an engine containing a train and validation loop
 
-    Any extra objects should be passed to this function such as:
+    Any extra objects should be added to the engine state such as:
     - Optimizers
     - Loss functions
     This is to ensure we can access these objects 
     through callbacks in train_pipeline.py
-
-    WARNING: If we initilize anything other than the engine here, 
-    we will not be able to access it through callbacks
     """
-
+    # TRAIN
     optimizer = idist.auto_optim(hydra.utils.instantiate(config.engine.optimizer, params=model.parameters()))
     criterion = hydra.utils.instantiate(config.engine.criterion).to(idist.device())
     
@@ -53,10 +54,40 @@ def create_engine(model: nn.Module, config: DictConfig):
     engine.state.criterion = criterion
     engine.state.optimizer = optimizer
 
-
     if idist.get_rank() == 0:
         # Add progress bar showing batch loss value
         ProgressBar().attach(engine, output_transform=lambda x: {"batch loss": x})
+
+    # VALIDATION
+    evaluator = create_supervised_evaluator(
+        model,
+        metrics={"accuracy": ignite.metrics.Accuracy(), "loss": ignite.metrics.Loss(engine.state.criterion)},
+        device=idist.device(),
+    )
+    engine.state.evaluator = evaluator
+    def function(engine, log_to_wandb=config.engine.log_to_wandb):
+        state = engine.state.evaluator.run(engine.state.dataloaders.val)
+        if idist.get_rank() == 0:
+            log.info(state.metrics)
+            if log_to_wandb:
+                wandb.log(state.metrics)
+                log.info("Logged to Wandb")
+    engine.add_event_handler(Events.EPOCH_COMPLETED, function)
+
+    # save best 3 models based upon evaluation
+    to_save = {
+        'model': model,
+        'engine': engine
+    }
+    handler = ignite.handlers.checkpoint.Checkpoint(
+        to_save, 
+        os.getcwd(),
+        n_saved=3,
+        filename_prefix='best',
+        score_name="accuracy",
+    )
+    log.info(f"Saving best models to: {os.getcwd()}")
+    engine.state.evaluator.add_event_handler(Events.COMPLETED, handler)
 
     return engine
 

--- a/src/train_pipeline.py
+++ b/src/train_pipeline.py
@@ -61,9 +61,10 @@ def train(local_rank, config: DictConfig):
 
     # Add callbacks to engine
     if isinstance(config.callbacks, DictConfig):
-        for callback in config.callbacks.values():
-            log.info(f"Initializing Callback: {callback}")
-            hydra.utils.instantiate(callback, engine)
+        for event, callbacks in config.callbacks.items():
+            for callback in callbacks.values():
+                engine.add_event_handler(event, hydra.utils.get_method(callback))
+                log.info(f"Initializing Callback: {callback}")
     
     # restore engine state if applicable
     if config.resume_from:


### PR DESCRIPTION
Simplifies callbacks by allowing the user to write only the function and to specify the event it is assigned to through the config file also removes the code to add it to the engine. 
Additionally the evaluation code is moved into the supervised trainer so both the train and validation loops are written in the same place.